### PR TITLE
Fix link that was broken after file rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mozilla Science Lab Code of Conduct
-This repository holds the [Mozilla Science Lab's Code of Conduct](https://github.com/mozillascience/code_of_conduct/blob/master/code.md). 
+This repository holds the [Mozilla Science Lab's Code of Conduct](https://github.com/mozillascience/code_of_conduct/blob/master/CODE_OF_CONDUCT.md). 
 You can view our Code [online](https://mozillascience.org/code-of-conduct) or access here in the repository.
 
-Looking to create your own Code of Conduct for your event, project or community? Have a look at our ["Getting Started with Code of Conducts" lesson](http://mozillascience.github.io/working-open-workshop/code_of_conduct/). You are also welcome to [remix ours](https://github.com/mozillascience/code_of_conduct/blob/master/code.md) (it's under CC0, in the public domain and open for all to use). 
+Looking to create your own Code of Conduct for your event, project or community? Have a look at our ["Getting Started with Code of Conducts" lesson](http://mozillascience.github.io/working-open-workshop/code_of_conduct/). You are also welcome to [remix ours](https://github.com/mozillascience/code_of_conduct/blob/master/CODE_OF_CONDUCT.md) (it's under CC0, in the public domain and open for all to use). 


### PR DESCRIPTION
When `code.md` was renamed to `CODE_OF_CONDUCT.md`, the links in the README weren't updated. :)

Pinging @kaythaney.
